### PR TITLE
Enable GDAL deprecated GTM driver for fiona-feedstock build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,7 @@ test:
   files:
     - test_data
   commands:
+    - export GDAL_ENABLE_DEPRECATED_DRIVER_GTM=YES # [not win]
     - fio --help
     - fio ls test_data/test.shp
     - fio info test_data/test.shp


### PR DESCRIPTION
Attempt to fix build error at https://github.com/conda-forge/fiona-feedstock/pull/179.