### PR TITLE
Use script_env for GDAL deprecated GTM driver during build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ build:
   skip: true  # [win and vc<14]
   entry_points:
     - fio = fiona.fio.main:main_group
+  script_env:
+    - GDAL_ENABLE_DEPRECATED_DRIVER_GTM=YES # [not win]
 
 requirements:
   build:


### PR DESCRIPTION
Attempt to fix build error at conda-forge at [#179](https://github.com/conda-forge/fiona-feedstock/pull/179).